### PR TITLE
feat: Remove dependency on jcenter.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ buildscript {
     ext.kotlin_version = "1.4.20"
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
     dependencies {
         classpath "com.android.tools.build:gradle:4.1.1"
@@ -17,7 +17,7 @@ buildscript {
 allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 }
 


### PR DESCRIPTION
Remove jcenter repo. Currently still fails due to:

```
A problem occurred configuring root project 'secrets-plugin'.
> Could not resolve all artifacts for configuration ':classpath'.
   > Could not find org.jetbrains.trove4j:trove4j:20160824.
     Searched in the following locations:
       - https://dl.google.com/dl/android/maven2/org/jetbrains/trove4j/trove4j/20160824/trove4j-20160824.pom
       - https://repo.maven.apache.org/maven2/org/jetbrains/trove4j/trove4j/20160824/trove4j-20160824.pom
     Required by:
         project : > com.android.tools.build:gradle:4.1.1 > com.android.tools.build:builder:4.1.1 > com.android.tools:sdk-common:27.1.1

Possible solution:
 - Declare repository providing the artifact, see the documentation at https://docs.gradle.org/current/userguide/declaring_repositories.html
```
