### PR TITLE
fix: Adding Quotes to Manifest Example

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ After applying the plugin and building your project, the API key then becomes ac
   ```
   2. As a variable accessible in your `AndroidManifest.xml` file:
   ```xml
-  <meta-data android:value=${apiKey} />
+  <meta-data android:value="${apiKey}" />
   ```
 
 ## Configuration Options


### PR DESCRIPTION
When trying to use the plugin myself I came across this issue. Simple change, but I think the documentation should reflect how to actually use variables in the manifest. 