### PR TITLE
chore: Rename maven artifact to com.google.android.libraries.mapsplatform.secrets-gradle-plugin

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@
 name: Release
 on:
   push:
-    branches: [ main ]
+    branches: [ ]
   workflow_dispatch:
 jobs:
   release:

--- a/README.md
+++ b/README.md
@@ -16,19 +16,42 @@ class and in the Android manifest file.
 
 ## Installation
 
-In your app-level `build.gradle` file:
+**NOTE**: Starting from v1.1.0, the maven coordinate of the plugin changed group ID to "com.google.android.libraries.mapsplatform.secrets-gradle-plugin" and artifact ID to "secrets-gradle-plugin" and is now being distributed via Google Maven.  You can still download previous versions of the plugin from Gradle's plugin portal.
+
+1. In your project's root `build.gradle` file:
+
+Groovy:
+```groovy
+buildscript {
+    dependencies {
+        classpath "com.google.android.libraries.mapsplatform.secrets-gradle-plugin:secrets-gradle-plugin:1.1.0"
+    }
+}
+```
+
+Kotlin:
+```kotlin
+buildscript {
+    dependencies {
+        classpath("com.google.android.libraries.mapsplatform.secrets-gradle-plugin:secrets-gradle-plugin:1.1.0")
+    }
+}
+```
+
+
+2. In your app-level `build.gradle` file:
 
 Groovy:
 ```groovy
 plugins {
-    id 'com.google.android.libraries.mapsplatform.secrets-gradle-plugin' version '1.1.0'
+    id 'com.google.android.libraries.mapsplatform.secrets-gradle-plugin'
 }
 ```
 
 Kotlin:
 ```groovy
 plugins {
-    id("com.google.android.libraries.mapsplatform.secrets-gradle-plugin") version "1.1.0"
+    id("com.google.android.libraries.mapsplatform.secrets-gradle-plugin")
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -21,14 +21,14 @@ In your app-level `build.gradle` file:
 Groovy:
 ```groovy
 plugins {
-    id 'com.google.android.secrets-gradle-plugin' version '1.1.0'
+    id 'com.google.android.libraries.mapsplatform.secrets-gradle-plugin' version '1.1.0'
 }
 ```
 
 Kotlin:
 ```groovy
 plugins {
-    id("com.google.android.secrets-gradle-plugin") version "1.1.0"
+    id("com.google.android.libraries.mapsplatform.secrets-gradle-plugin") version "1.1.0"
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ class and in the Android manifest file.
 
 ## Installation
 
-**NOTE**: Starting from v1.1.0, the maven coordinate of the plugin changed group ID to "com.google.android.libraries.mapsplatform.secrets-gradle-plugin" and artifact ID to "secrets-gradle-plugin" and is now being distributed via Google Maven.  You can still download previous versions of the plugin from Gradle's plugin portal.
+**NOTE**: Starting from v1.1.0, the maven coordinate of the plugin changed group ID to "com.google.android.libraries.mapsplatform.secrets-gradle-plugin" and artifact ID to "secrets-gradle-plugin" and is now being distributed via Google Maven (gMaven).  You can still download previous versions of the plugin from Gradle's plugin portal, but new versions will now only be distributed through gMaven.
 
 1. In your project's root `build.gradle` file:
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,13 +1,14 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
-    ext.kotlin_version = "1.4.20"
+    ext.kotlin_version = "1.4.32"
     repositories {
         google()
         mavenCentral()
     }
     dependencies {
-        classpath "com.android.tools.build:gradle:4.1.1"
+        classpath "com.android.tools.build:gradle:4.1.3"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
+        classpath "com.google.android.libraries.mapsplatform.secrets-gradle-plugin:secrets-gradle-plugin:1.1.0"
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/sample-app/build.gradle.kts
+++ b/sample-app/build.gradle.kts
@@ -17,7 +17,7 @@ plugins {
     id("kotlin-android")
 
     // 1. Include the plugin
-    id("com.google.secrets_gradle_plugin") version "0.6"
+    id("com.google.android.libraries.mapsplatform.secrets-gradle-plugin.secrets-gradle-plugin")
 }
 
 android {

--- a/secrets-gradle-plugin/build.gradle.kts
+++ b/secrets-gradle-plugin/build.gradle.kts
@@ -42,9 +42,9 @@ gradlePlugin {
 }
 
 pluginBundle {
-    website = "https://github.com/google/secrets-gradle-plugin"
-    vcsUrl = "https://github.com/google/secrets-gradle-plugin"
-    description = "A Gradle plugin for providing secrets securely to an Android project."
+    website = PluginInfo.url
+    vcsUrl = PluginInfo.url
+    description = PluginInfo.description
     version = PluginInfo.version
 
     (plugins) {
@@ -61,6 +61,38 @@ publishing {
             group = PluginInfo.group
             artifactId = PluginInfo.artifactId
             version = PluginInfo.version
+
+            pom {
+                name.set(PluginInfo.artifactId)
+                description.set(PluginInfo.description)
+                url.set(PluginInfo.url)
+
+                scm {
+                    connection.set("scm:git@github.com:google/secrets-gradle-plugin.git")
+                    developerConnection.set("scm:git@github.com:google/secrets-gradle-plugin.git")
+                    url.set(PluginInfo.url)
+                }
+
+                licenses {
+                    license {
+                        name.set("The Apache Software License, Version 2.0")
+                        url.set("http://www.apache.org/licenses/LICENSE-2.0.txt")
+                        distribution.set("repo")
+                    }
+                }
+
+                organization {
+                    name.set("Google Inc.")
+                    url.set("https://developers.google.com/maps")
+                }
+
+
+                developers {
+                    developer {
+                        name.set("Google Inc.")
+                    }
+                }
+            }
         }
     }
     repositories {
@@ -69,9 +101,11 @@ publishing {
 }
 
 object PluginInfo {
-    const val group = "com.google.android"
     const val artifactId = "secrets-gradle-plugin"
+    const val description = "A Gradle plugin for providing secrets securely to an Android project."
+    const val group = "com.google.android.libraries.mapsplatform.secrets-gradle-plugin"
+    const val implementationClass = "com.google.android.libraries.mapsplatform.secrets_gradle_plugin.SecretsPlugin"
     const val name = "secretsGradlePlugin"
+    const val url = "https://github.com/google/secrets-gradle-plugin"
     const val version = "1.1.0"
-    const val implementationClass = "com.google.android.secrets_gradle_plugin.SecretsPlugin"
 }

--- a/secrets-gradle-plugin/src/main/java/com/google/android/libraries/mapsplatform/secrets_gradle_plugin/Extensions.kt
+++ b/secrets-gradle-plugin/src/main/java/com/google/android/libraries/mapsplatform/secrets_gradle_plugin/Extensions.kt
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package com.google.android.secrets_gradle_plugin
+package com.google.android.libraries.mapsplatform.secrets_gradle_plugin
 
 import com.android.build.gradle.AppExtension
 import com.android.build.gradle.LibraryExtension

--- a/secrets-gradle-plugin/src/main/java/com/google/android/libraries/mapsplatform/secrets_gradle_plugin/SecretsPlugin.kt
+++ b/secrets-gradle-plugin/src/main/java/com/google/android/libraries/mapsplatform/secrets_gradle_plugin/SecretsPlugin.kt
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package com.google.android.secrets_gradle_plugin
+package com.google.android.libraries.mapsplatform.secrets_gradle_plugin
 
 import com.android.build.gradle.internal.core.InternalBaseVariant
 import org.gradle.api.Plugin

--- a/secrets-gradle-plugin/src/main/java/com/google/android/libraries/mapsplatform/secrets_gradle_plugin/SecretsPluginExtension.kt
+++ b/secrets-gradle-plugin/src/main/java/com/google/android/libraries/mapsplatform/secrets_gradle_plugin/SecretsPluginExtension.kt
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package com.google.android.secrets_gradle_plugin
+package com.google.android.libraries.mapsplatform.secrets_gradle_plugin
 
 /**
  * Configuration object for [SecretsPlugin].

--- a/secrets-gradle-plugin/src/test/kotlin/com/google/android/libraries/mapsplatform/secrets_gradle_plugin/SecretsPluginTest.kt
+++ b/secrets-gradle-plugin/src/test/kotlin/com/google/android/libraries/mapsplatform/secrets_gradle_plugin/SecretsPluginTest.kt
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package com.google.android.secrets_gradle_plugin
+package com.google.android.libraries.mapsplatform.secrets_gradle_plugin
 
 import com.android.build.gradle.internal.core.InternalBaseVariant
 import com.nhaarman.mockitokotlin2.doReturn
@@ -57,7 +57,7 @@ class SecretsPluginTest {
         variant = mock() {
             on { mergedFlavor } doReturn flavor
         }
-        project.pluginManager.apply("com.google.android.secrets-gradle-plugin")
+        project.pluginManager.apply("com.google.android.libraries.mapsplatform.secrets-gradle-plugin.secrets-gradle-plugin")
     }
 
     @Test(expected = ProjectConfigurationException::class)


### PR DESCRIPTION
New maven coordinate: `com.google.android.libraries.mapsplatform.secrets-gradle-plugin`
