### PR TITLE
chore: Release 2.0.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 .externalNativeBuild
 .cxx
 local.properties
+.java-version

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ class and in the Android manifest file.
 
 ## Requirements
 * Gradle-based Android project
-* Android Gradle plugin 4.1.x or newer
+* Android Gradle plugin 7.0.0
 
 ## Installation
 
@@ -24,7 +24,7 @@ Groovy:
 ```groovy
 buildscript {
     dependencies {
-        classpath "com.google.android.libraries.mapsplatform.secrets-gradle-plugin:secrets-gradle-plugin:1.2.0"
+        classpath "com.google.android.libraries.mapsplatform.secrets-gradle-plugin:secrets-gradle-plugin:2.0.0"
     }
 }
 ```
@@ -33,7 +33,7 @@ Kotlin:
 ```kotlin
 buildscript {
     dependencies {
-        classpath("com.google.android.libraries.mapsplatform.secrets-gradle-plugin:secrets-gradle-plugin:1.2.0")
+        classpath("com.google.android.libraries.mapsplatform.secrets-gradle-plugin:secrets-gradle-plugin:2.0.0")
     }
 }
 ```

--- a/build.gradle
+++ b/build.gradle
@@ -7,9 +7,9 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath "com.android.tools.build:gradle:4.2.1"
+        classpath "com.android.tools.build:gradle:7.0.0-beta04"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-        classpath "com.google.android.libraries.mapsplatform.secrets-gradle-plugin:secrets-gradle-plugin:1.3.0"
+        classpath "com.google.android.libraries.mapsplatform.secrets-gradle-plugin:secrets-gradle-plugin:1.4.0"
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/build.gradle
+++ b/build.gradle
@@ -5,11 +5,18 @@ buildscript {
         mavenLocal()
         google()
         mavenCentral()
+        maven {
+            url = uri("https://maven.pkg.github.com/google/secrets-gradle-plugin")
+            credentials {
+                username = project.findProperty("ghGprUser") ?: System.getenv("ghGprUser")
+                password = project.findProperty("ghGprToken") ?: System.getenv("ghGprToken")
+            }
+        }
     }
     dependencies {
         classpath "com.android.tools.build:gradle:7.0.0-beta04"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-        classpath "com.google.android.libraries.mapsplatform.secrets-gradle-plugin:secrets-gradle-plugin:1.4.0"
+        classpath "com.google.android.libraries.mapsplatform.secrets-gradle-plugin:secrets-gradle-plugin:2.0.0-SNAPSHOT"
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
-    ext.kotlin_version = "1.4.32"
+    ext.kotlin_version = "1.5.20"
     repositories {
         mavenLocal()
         google()
@@ -14,9 +14,9 @@ buildscript {
         }
     }
     dependencies {
-        classpath "com.android.tools.build:gradle:7.0.0-beta04"
+        classpath "com.android.tools.build:gradle:7.0.0"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-        classpath "com.google.android.libraries.mapsplatform.secrets-gradle-plugin:secrets-gradle-plugin:2.0.0-SNAPSHOT"
+        classpath "com.google.android.libraries.mapsplatform.secrets-gradle-plugin:secrets-gradle-plugin:2.0.0"
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/gradle.properties
+++ b/gradle.properties
@@ -22,3 +22,6 @@ kotlin.code.style=official
 
 gradle.publish.key=
 gradle.publish.secret=
+
+ghGprUser=
+ghGprToken=

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Thu Nov 26 22:14:52 PST 2020
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-all.zip

--- a/secrets-gradle-plugin/build.gradle.kts
+++ b/secrets-gradle-plugin/build.gradle.kts
@@ -87,14 +87,6 @@ publishing {
             name = "localPluginRepository"
             url = uri("build/repository")
         }
-        maven {
-            name = "GitHubPackages"
-            url = uri("https://maven.pkg.github.com/google/secrets-gradle-plugin")
-            credentials {
-                username = property("ghGprUser") as? String
-                password = property("ghGprToken") as? String
-            }
-        }
         mavenLocal()
     }
 }

--- a/secrets-gradle-plugin/build.gradle.kts
+++ b/secrets-gradle-plugin/build.gradle.kts
@@ -24,7 +24,7 @@ java {
 }
 
 dependencies {
-    compileOnly("com.android.tools.build:gradle:7.0.0-beta04")
+    compileOnly("com.android.tools.build:gradle:7.0.0")
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.4.10")
     testImplementation("com.android.tools.build:gradle:7.0.0-beta04")
     testImplementation("junit:junit:4.13.1")
@@ -113,5 +113,5 @@ object PluginInfo {
         "com.google.android.libraries.mapsplatform.secrets_gradle_plugin.SecretsPlugin"
     const val name = "secretsGradlePlugin"
     const val url = "https://github.com/google/secrets-gradle-plugin"
-    const val version = "2.0.0-SNAPSHOT"
+    const val version = "2.0.0"
 }

--- a/secrets-gradle-plugin/build.gradle.kts
+++ b/secrets-gradle-plugin/build.gradle.kts
@@ -25,9 +25,9 @@ java {
 }
 
 dependencies {
-    compileOnly("com.android.tools.build:gradle:4.2.1")
+    compileOnly("com.android.tools.build:gradle:7.0.0-beta04")
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.4.10")
-    testImplementation("com.android.tools.build:gradle:4.2.1")
+    testImplementation("com.android.tools.build:gradle:7.0.0-beta04")
     testImplementation("junit:junit:4.13.1")
     testImplementation("com.nhaarman.mockitokotlin2:mockito-kotlin:2.2.0")
 }
@@ -111,5 +111,5 @@ object PluginInfo {
     const val implementationClass = "com.google.android.libraries.mapsplatform.secrets_gradle_plugin.SecretsPlugin"
     const val name = "secretsGradlePlugin"
     const val url = "https://github.com/google/secrets-gradle-plugin"
-    const val version = "1.3.0"
+    const val version = "1.4.0"
 }

--- a/secrets-gradle-plugin/build.gradle.kts
+++ b/secrets-gradle-plugin/build.gradle.kts
@@ -15,7 +15,6 @@
 plugins {
     `java-gradle-plugin`
     `maven-publish`
-    id("com.gradle.plugin-publish") version "0.12.0"
     id("kotlin")
 }
 
@@ -39,20 +38,6 @@ gradlePlugin {
             implementationClass = PluginInfo.implementationClass
             displayName = PluginInfo.displayName
             description = PluginInfo.description
-        }
-    }
-}
-
-pluginBundle {
-    website = PluginInfo.url
-    vcsUrl = PluginInfo.url
-    description = PluginInfo.description
-    version = PluginInfo.version
-
-    (plugins) {
-        PluginInfo.name {
-            displayName = PluginInfo.displayName
-            tags = listOf("kotlin", "android")
         }
     }
 }
@@ -98,18 +83,35 @@ publishing {
         }
     }
     repositories {
-        maven(url = "build/repository")
+        maven {
+            name = "localPluginRepository"
+            url = uri("build/repository")
+        }
+        maven {
+            name = "GitHubPackages"
+            url = uri("https://maven.pkg.github.com/google/secrets-gradle-plugin")
+            credentials {
+                username = property("ghGprUser") as? String
+                password = property("ghGprToken") as? String
+            }
+        }
         mavenLocal()
     }
 }
 
+project(":secrets-gradle-plugin") {
+    version = PluginInfo.version
+}
+
 object PluginInfo {
-    const val artifactId = "com.google.android.libraries.mapsplatform.secrets-gradle-plugin.gradle.plugin"
+    const val artifactId =
+        "com.google.android.libraries.mapsplatform.secrets-gradle-plugin.gradle.plugin"
     const val description = "A Gradle plugin for providing secrets securely to an Android project."
     const val displayName = "Secrets Gradle Plugin for Android"
     const val group = "com.google.android.libraries.mapsplatform.secrets-gradle-plugin"
-    const val implementationClass = "com.google.android.libraries.mapsplatform.secrets_gradle_plugin.SecretsPlugin"
+    const val implementationClass =
+        "com.google.android.libraries.mapsplatform.secrets_gradle_plugin.SecretsPlugin"
     const val name = "secretsGradlePlugin"
     const val url = "https://github.com/google/secrets-gradle-plugin"
-    const val version = "1.4.0"
+    const val version = "2.0.0-SNAPSHOT"
 }

--- a/secrets-gradle-plugin/src/main/java/com/google/android/libraries/mapsplatform/secrets_gradle_plugin/Extensions.kt
+++ b/secrets-gradle-plugin/src/main/java/com/google/android/libraries/mapsplatform/secrets_gradle_plugin/Extensions.kt
@@ -16,9 +16,9 @@
 
 package com.google.android.libraries.mapsplatform.secrets_gradle_plugin
 
-import com.android.build.api.extension.ApplicationAndroidComponentsExtension
-import com.android.build.api.extension.LibraryAndroidComponentsExtension
+import com.android.build.api.variant.ApplicationAndroidComponentsExtension
 import com.android.build.api.variant.BuildConfigField
+import com.android.build.api.variant.LibraryAndroidComponentsExtension
 import com.android.build.api.variant.Variant
 import com.android.build.gradle.AppExtension
 import com.android.build.gradle.LibraryExtension


### PR DESCRIPTION
## Summary of Changes
- chore: Using AGP 7.0.0 and bump version to 2.0.0
- chore: Adding GPR repo and 2.0.0-SNAPSHOT.
- fix: Use AndroidComponentsExtension from com.android.build.api.variant package.

Fixes #36
