### PR TITLE
Remove misleading double quotes

### DIFF
--- a/secrets-gradle-plugin/build.gradle.kts
+++ b/secrets-gradle-plugin/build.gradle.kts
@@ -105,5 +105,5 @@ object PluginInfo {
         "com.google.android.libraries.mapsplatform.secrets_gradle_plugin.SecretsPlugin"
     const val name = "secretsGradlePlugin"
     const val url = "https://github.com/google/secrets-gradle-plugin"
-    const val version = "2.0.0"
+    const val version = "2.0.1"
 }

--- a/secrets-gradle-plugin/src/main/java/com/google/android/libraries/mapsplatform/secrets_gradle_plugin/Extensions.kt
+++ b/secrets-gradle-plugin/src/main/java/com/google/android/libraries/mapsplatform/secrets_gradle_plugin/Extensions.kt
@@ -63,7 +63,7 @@ fun Variant.inject(properties: Properties, ignore: List<String>) {
     }.filter { key ->
         key.isNotEmpty() && !ignoreRegexs.any { it.containsMatchIn(key) }
     }.forEach { key ->
-        val value = properties.getProperty(key)
+        val value = properties.getProperty(key).removeSurrounding("\"")
         val translatedKey = key.replace(javaVarRegexp, "")
         buildConfigFields.put(
             translatedKey,


### PR DESCRIPTION
According to this issue: https://github.com/google/secrets-gradle-plugin/issues/46
and also my personal pain and experience, there is a misleading double quote in the sample files, and that caused me to not able to use the maps and suffer a couple of days, so I thought we can fix the documentation or better, we can remove them from the string so it will work both ways.