### PR TITLE
fix: Remove misleading double quotes

### DIFF
--- a/secrets-gradle-plugin/build.gradle.kts
+++ b/secrets-gradle-plugin/build.gradle.kts
@@ -105,5 +105,5 @@ object PluginInfo {
         "com.google.android.libraries.mapsplatform.secrets_gradle_plugin.SecretsPlugin"
     const val name = "secretsGradlePlugin"
     const val url = "https://github.com/google/secrets-gradle-plugin"
-    const val version = "2.0.1"
+    const val version = "2.0.0"
 }

--- a/secrets-gradle-plugin/build.gradle.kts
+++ b/secrets-gradle-plugin/build.gradle.kts
@@ -105,5 +105,5 @@ object PluginInfo {
         "com.google.android.libraries.mapsplatform.secrets_gradle_plugin.SecretsPlugin"
     const val name = "secretsGradlePlugin"
     const val url = "https://github.com/google/secrets-gradle-plugin"
-    const val version = "2.0.0"
+    const val version = "2.0.1"
 }

--- a/secrets-gradle-plugin/src/main/java/com/google/android/libraries/mapsplatform/secrets_gradle_plugin/Extensions.kt
+++ b/secrets-gradle-plugin/src/main/java/com/google/android/libraries/mapsplatform/secrets_gradle_plugin/Extensions.kt
@@ -63,7 +63,7 @@ fun Variant.inject(properties: Properties, ignore: List<String>) {
     }.filter { key ->
         key.isNotEmpty() && !ignoreRegexs.any { it.containsMatchIn(key) }
     }.forEach { key ->
-        val value = properties.getProperty(key)
+        val value = properties.getProperty(key).removeSurrounding("\"")
         val translatedKey = key.replace(javaVarRegexp, "")
         buildConfigFields.put(
             translatedKey,

--- a/secrets-gradle-plugin/src/main/java/com/google/android/libraries/mapsplatform/secrets_gradle_plugin/Extensions.kt
+++ b/secrets-gradle-plugin/src/main/java/com/google/android/libraries/mapsplatform/secrets_gradle_plugin/Extensions.kt
@@ -80,7 +80,7 @@ fun InternalBaseVariant.inject(properties: Properties, ignore: List<String>) {
     }.filter { key ->
         key.isNotEmpty() && !ignoreRegexs.any { it.containsMatchIn(key) }
     }.forEach { key ->
-        val value = properties.getProperty(key)
+        val value = properties.getProperty(key).removeSurrounding("\"")
         val translatedKey = key.replace(javaVarRegexp, "")
         buildConfigField("String", translatedKey, value.addParenthesisIfNeeded())
         mergedFlavor.manifestPlaceholders[translatedKey] = value

--- a/secrets-gradle-plugin/src/test/kotlin/com/google/android/libraries/mapsplatform/secrets_gradle_plugin/SecretsPluginTest.kt
+++ b/secrets-gradle-plugin/src/test/kotlin/com/google/android/libraries/mapsplatform/secrets_gradle_plugin/SecretsPluginTest.kt
@@ -90,7 +90,7 @@ class SecretsPluginTest {
         variant.inject(properties = properties, ignore = ignoreList)
 
         check(
-            Pair("key", "\"someValue\"")
+            Pair("key", "someValue")
         )
         checkKeysNotIn("ignoreKey", "sdk.dir", "sdk.foo")
     }
@@ -110,8 +110,8 @@ class SecretsPluginTest {
         variant.inject(properties = properties, ignore = emptyList())
 
         check(
-            Pair("key1", "\"someValue1\""),
-            Pair("key2", "\"someValue2\""),
+            Pair("key1", "someValue1"),
+            Pair("key2", "someValue2"),
         )
     }
 
@@ -130,8 +130,8 @@ class SecretsPluginTest {
         variant.inject(properties = properties, ignore = emptyList())
 
         check(
-            Pair("sdkDir", "\"value\""),
-            Pair("sdkFoo", "\"value2\"")
+            Pair("sdkDir", "value"),
+            Pair("sdkFoo", "value2")
         )
     }
 
@@ -150,7 +150,7 @@ class SecretsPluginTest {
         variant.inject(properties = properties, ignore = emptyList())
 
         check(
-            Pair("key1", "\"value\""),
+            Pair("key1", "value"),
             Pair("key2", "value2")
         )
     }


### PR DESCRIPTION
According to this issue: https://github.com/google/secrets-gradle-plugin/issues/46
and also my personal pain and experience, there is a misleading double quotes in the sample files, and that caused me to not able to use the maps and suffer a couple of days, so I thought we can fix the documentation or better, we can remove them from the string so it will work both ways

Signed-off-by: Amin Keshavarzian <ak@next-munich.com>