### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,15 @@ plugins {
 }
 ```
 
+Enable a `BuildConfig` feature:
+```groovy
+android {
+    buildFeatures {
+        buildConfig = true
+    }
+}
+```
+
 This plugin also supports library module type (`com.android.library`). Just install the plugin in your library-level `build.gradle` file and keys will be visible inside that module as well.
 
 ### Snapshot Releases

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ plugins {
 }
 ```
 
-Enable a `BuildConfig` feature:
+3. Enable the `BuildConfig` functionality in the `build.gradle` file at the app level:
 ```groovy
 android {
     buildFeatures {


### PR DESCRIPTION
Added an explanation that BuildConfig needs to be included in buildFeatures at the application level.