### PR TITLE
Depend on AGP API artifact only

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,4 @@
 [versions]
-gradle = "7.0.4"
 gradleVersion = "8.4.2"
 junit = "4.13.2"
 kotlin = "1.9.24"
@@ -10,7 +9,7 @@ mockitoKotlin = "2.2.0"
 secretsGradlePlugin = "2.0.1"
 
 [libraries]
-gradle = { module = "com.android.tools.build:gradle", version.ref = "gradle" }
+agp-api = "com.android.tools.build:gradle-api:7.0.4"
 gradle-v842 = { module = "com.android.tools.build:gradle", version.ref = "gradleVersion" }
 junit = { module = "junit:junit", version.ref = "junit" }
 kotlin-gradle-plugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlinGradlePlugin" }

--- a/secrets-gradle-plugin/build.gradle.kts
+++ b/secrets-gradle-plugin/build.gradle.kts
@@ -24,9 +24,9 @@ java {
 }
 
 dependencies {
-    compileOnly(libs.gradle)
+    compileOnly(libs.agp.api)
     implementation(libs.kotlin.stdlib)
-    testImplementation(libs.gradle)
+    testImplementation(libs.agp.api)
     testImplementation(libs.junit)
     testImplementation(libs.mockito.kotlin)
 }

--- a/secrets-gradle-plugin/src/main/java/com/google/android/libraries/mapsplatform/secrets_gradle_plugin/Extensions.kt
+++ b/secrets-gradle-plugin/src/main/java/com/google/android/libraries/mapsplatform/secrets_gradle_plugin/Extensions.kt
@@ -20,9 +20,6 @@ import com.android.build.api.variant.ApplicationAndroidComponentsExtension
 import com.android.build.api.variant.BuildConfigField
 import com.android.build.api.variant.LibraryAndroidComponentsExtension
 import com.android.build.api.variant.Variant
-import com.android.build.gradle.AppExtension
-import com.android.build.gradle.LibraryExtension
-import com.android.build.gradle.internal.core.InternalBaseVariant
 import org.gradle.api.Project
 import java.io.FileNotFoundException
 import java.util.Properties
@@ -32,12 +29,6 @@ fun Project.androidAppComponent(): ApplicationAndroidComponentsExtension? =
 
 fun Project.androidLibraryComponent(): LibraryAndroidComponentsExtension? =
     extensions.findByType(LibraryAndroidComponentsExtension::class.java)
-
-fun Project.androidProject(): AppExtension? =
-    extensions.findByType(AppExtension::class.java)
-
-fun Project.libraryProject(): LibraryExtension? =
-    extensions.findByType(LibraryExtension::class.java)
 
 fun Project.loadPropertiesFile(fileName: String): Properties {
     // Load file
@@ -70,20 +61,6 @@ fun Variant.inject(properties: Properties, ignore: List<String>) {
             BuildConfigField("String", value.addParenthesisIfNeeded(), null)
         )
         manifestPlaceholders.put(translatedKey, value)
-    }
-}
-
-fun InternalBaseVariant.inject(properties: Properties, ignore: List<String>) {
-    val ignoreRegexs = ignore.map { Regex(pattern = it) }
-    properties.keys.map { key ->
-        key as String
-    }.filter { key ->
-        key.isNotEmpty() && !ignoreRegexs.any { it.containsMatchIn(key) }
-    }.forEach { key ->
-        val value = properties.getProperty(key).removeSurrounding("\"")
-        val translatedKey = key.replace(javaVarRegexp, "")
-        buildConfigField("String", translatedKey, value.addParenthesisIfNeeded())
-        mergedFlavor.manifestPlaceholders[translatedKey] = value
     }
 }
 

--- a/secrets-gradle-plugin/src/main/java/com/google/android/libraries/mapsplatform/secrets_gradle_plugin/SecretsPlugin.kt
+++ b/secrets-gradle-plugin/src/main/java/com/google/android/libraries/mapsplatform/secrets_gradle_plugin/SecretsPlugin.kt
@@ -16,7 +16,6 @@
 package com.google.android.libraries.mapsplatform.secrets_gradle_plugin
 
 import com.android.build.api.variant.Variant
-import com.android.build.gradle.internal.core.InternalBaseVariant
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import java.io.FileNotFoundException


### PR DESCRIPTION
Avoid using AGP internal APIs in this plugin, we have fully migrated to `AndroidComponentsExtension`.