### PR TITLE
Include build plugin project and show keys in MainActivity

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  run-unit-test:
+  build:
     runs-on: ubuntu-latest
 
     steps:
@@ -37,7 +37,11 @@ jobs:
         java-version: '17'
         distribution: 'temurin'
 
-    - name: Run tests
+    - name: Run root project build
+      run: |
+        ./gradlew build --stacktrace
+
+    - name: Run plugin build
       run: |
         echo "Running unit tests"
-        ./gradlew :secrets-gradle-plugin:build check test -x lint --stacktrace
+        ./gradlew :secrets-gradle-plugin:build --stacktrace

--- a/.releaserc
+++ b/.releaserc
@@ -18,8 +18,8 @@ plugins:
           from: "version '.*'"
           to: "version '${nextRelease.version}'"
   - - "@semantic-release/exec"
-    - prepareCmd: "./gradlew build --warn --stacktrace"
-      publishCmd: "./gradlew publishPlugins --warn --stacktrace"
+    - prepareCmd: "./gradlew :secrets-gradle-plugin:build --warn --stacktrace"
+      publishCmd: "./gradlew :secrets-gradle-plugin:publishPlugins --warn --stacktrace"
   - - "@semantic-release/git"
     - assets:
         - "./secrets-gradle-plugin/build.gradle.kts"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,36 +11,11 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-buildscript {
 
-    repositories {
-        mavenLocal()
-        google()
-        mavenCentral()
-        maven {
-            url = uri("https://maven.pkg.github.com/google/secrets-gradle-plugin")
-            credentials {
-                username = project.findProperty("ghGprUser") as String? ?: System.getenv("ghGprUser")
-                password = project.findProperty("ghGprToken") as String? ?: System.getenv("ghGprToken")
-            }
-        }
-    }
-
-    dependencies {
-        classpath(libs.gradle.v842)
-        classpath(libs.kotlin.gradle.plugin)
-        classpath(libs.secrets.gradle.plugin)
-
-        // NOTE: Do not place your application dependencies here; they belong
-        // in the individual module build.gradle.kts files
-    }
-}
-
-allprojects {
-    repositories {
-        google()
-        mavenCentral()
-    }
+plugins {
+    alias(libs.plugins.android.application) apply false
+    alias(libs.plugins.kotlin.android) apply false
+    alias(libs.plugins.kotlin.jvm) apply false
 }
 
 tasks.register<Delete>("clean") {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,21 +1,23 @@
 [versions]
 gradle = "7.0.4"
-gradleVersion = "8.4.2"
+agp = "8.4.2"
 junit = "4.13.2"
 kotlin = "1.9.24"
 kotlinGradlePlugin = "2.0.0"
 material = "1.12.0"
 appcompat = "1.7.0"
 mockitoKotlin = "2.2.0"
-secretsGradlePlugin = "2.0.1"
 
 [libraries]
 gradle = { module = "com.android.tools.build:gradle", version.ref = "gradle" }
-gradle-v842 = { module = "com.android.tools.build:gradle", version.ref = "gradleVersion" }
 junit = { module = "junit:junit", version.ref = "junit" }
 kotlin-gradle-plugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlinGradlePlugin" }
 kotlin-stdlib = { group = "org.jetbrains.kotlin", name = "kotlin-stdlib-jdk8", version.ref = "kotlin" }
 material = { group = "com.google.android.material", name = "material", version.ref = "material" }
 appcompat = { group = "androidx.appcompat", name = "appcompat", version.ref = "appcompat" }
 mockito-kotlin = { module = "com.nhaarman.mockitokotlin2:mockito-kotlin", version.ref = "mockitoKotlin" }
-secrets-gradle-plugin = { module = "com.google.android.libraries.mapsplatform.secrets-gradle-plugin:secrets-gradle-plugin", version.ref = "secretsGradlePlugin" }
+
+[plugins]
+android-application = { id = "com.android.application", version.ref = "agp" }
+kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
+kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }

--- a/sample-app/build.gradle.kts
+++ b/sample-app/build.gradle.kts
@@ -13,10 +13,8 @@
 // limitations under the License.
 
 plugins {
-    id("com.android.application")
-    id("kotlin-android")
-
-    // 1. Include the plugin
+    alias(libs.plugins.android.application)
+    alias(libs.plugins.kotlin.android)
     id("com.google.android.libraries.mapsplatform.secrets-gradle-plugin")
 }
 

--- a/sample-app/src/main/java/com/google/secrets_gradle_plugin/sample/MainActivity.kt
+++ b/sample-app/src/main/java/com/google/secrets_gradle_plugin/sample/MainActivity.kt
@@ -14,10 +14,47 @@
 
 package com.google.secrets_gradle_plugin.sample
 
+import android.content.pm.PackageManager
+import android.os.Bundle
+import android.widget.LinearLayout
+import android.widget.TextView
 import androidx.appcompat.app.AppCompatActivity
+import com.google.secrets_plugin.sample.BuildConfig
 
 /**
  * Dummy activity. See build.gradle.kts for sample usage of the plugin.
  */
 class MainActivity : AppCompatActivity() {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        val buildConfigApiKey = BuildConfig.gmpApiKey
+        val manifestApiKey = getMetaValueFromManifest()
+
+        val textView = TextView(this).apply {
+            @Suppress("SetTextI18n")
+            text = """
+                GMP API Key in BuildConfig: $buildConfigApiKey
+                GMP API Key in AndroidManifest: $manifestApiKey
+            """.trimIndent()
+        }
+        val linearLayout = LinearLayout(this).apply {
+            layoutParams = LinearLayout.LayoutParams(
+                LinearLayout.LayoutParams.MATCH_PARENT,
+                LinearLayout.LayoutParams.MATCH_PARENT
+            )
+            addView(textView)
+        }
+        setContentView(linearLayout)
+    }
+
+    private fun getMetaValueFromManifest(
+        key: String = "com.google.android.geo.API_KEY"
+    ): String? {
+        return runCatching {
+            val appInfo = packageManager.getApplicationInfo(packageName, PackageManager.GET_META_DATA)
+            appInfo.metaData.getString(key)
+        }.getOrNull()
+    }
 }

--- a/secrets-gradle-plugin/build.gradle.kts
+++ b/secrets-gradle-plugin/build.gradle.kts
@@ -15,7 +15,7 @@
 plugins {
     `java-gradle-plugin`
     `maven-publish`
-    id("kotlin")
+    alias(libs.plugins.kotlin.jvm)
 }
 
 java {
@@ -91,9 +91,7 @@ publishing {
     }
 }
 
-project(":secrets-gradle-plugin") {
-    version = PluginInfo.version
-}
+version = PluginInfo.version
 
 object PluginInfo {
     const val artifactId =

--- a/secrets-gradle-plugin/settings.gradle.kts
+++ b/secrets-gradle-plugin/settings.gradle.kts
@@ -1,0 +1,20 @@
+dependencyResolutionManagement {
+    repositories {
+        google {
+            mavenContent {
+                includeGroupAndSubgroups("androidx")
+                includeGroupAndSubgroups("com.android")
+                includeGroupAndSubgroups("com.google")
+            }
+        }
+        mavenCentral()
+    }
+
+    versionCatalogs {
+        create("libs") {
+            from(files("../gradle/libs.versions.toml"))
+        }
+    }
+}
+
+rootProject.name = "secrets-gradle-plugin"

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -12,13 +12,35 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-include(":secrets-gradle-plugin")
-include(":sample-app")
-
 pluginManagement {
     repositories {
-        mavenLocal()
-        maven(url = "./plugin/build/repository")
+        google {
+            mavenContent {
+                includeGroupAndSubgroups("androidx")
+                includeGroupAndSubgroups("com.android")
+                includeGroupAndSubgroups("com.google")
+            }
+        }
+        mavenCentral()
         gradlePluginPortal()
     }
+
+    includeBuild("secrets-gradle-plugin")
 }
+
+dependencyResolutionManagement {
+    repositories {
+        google {
+            mavenContent {
+                includeGroupAndSubgroups("androidx")
+                includeGroupAndSubgroups("com.android")
+                includeGroupAndSubgroups("com.google")
+            }
+        }
+        mavenCentral()
+    }
+}
+
+rootProject.name = "secrets-gradle-plugin-root"
+
+include(":sample-app")


### PR DESCRIPTION
It would be easier to test the plugin logic in the sample App, we don't have to rely on the published version.