### PR TITLE
Inject manifest placeholders into test components

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,7 @@
 [versions]
-gradle = "7.0.4"
+# 7.4.0 is the first AGP exposing `manifestPlaceholders` on test components; kept minimal
+# for AGP 7.x consumers. Sample app and tests still build against `gradleVersion` below.
+gradle = "7.4.0"
 gradleVersion = "8.4.2"
 junit = "4.13.2"
 kotlin = "1.9.24"

--- a/secrets-gradle-plugin/src/main/java/com/google/android/libraries/mapsplatform/secrets_gradle_plugin/Extensions.kt
+++ b/secrets-gradle-plugin/src/main/java/com/google/android/libraries/mapsplatform/secrets_gradle_plugin/Extensions.kt
@@ -19,6 +19,7 @@ package com.google.android.libraries.mapsplatform.secrets_gradle_plugin
 import com.android.build.api.variant.ApplicationAndroidComponentsExtension
 import com.android.build.api.variant.BuildConfigField
 import com.android.build.api.variant.LibraryAndroidComponentsExtension
+import com.android.build.api.variant.TestComponent
 import com.android.build.api.variant.Variant
 import com.android.build.gradle.AppExtension
 import com.android.build.gradle.LibraryExtension
@@ -69,6 +70,20 @@ fun Variant.inject(properties: Properties, ignore: List<String>) {
             translatedKey,
             BuildConfigField("String", value.addParenthesisIfNeeded(), null)
         )
+        manifestPlaceholders.put(translatedKey, value)
+    }
+}
+
+/** Test components only expose [manifestPlaceholders] (no BuildConfig), so inject just those. */
+fun TestComponent.inject(properties: Properties, ignore: List<String>) {
+    val ignoreRegexs = ignore.map { Regex(pattern = it) }
+    properties.keys.map { key ->
+        key as String
+    }.filter { key ->
+        key.isNotEmpty() && !ignoreRegexs.any { it.containsMatchIn(key) }
+    }.forEach { key ->
+        val value = properties.getProperty(key).removeSurrounding("\"")
+        val translatedKey = key.replace(javaVarRegexp, "")
         manifestPlaceholders.put(translatedKey, value)
     }
 }

--- a/secrets-gradle-plugin/src/main/java/com/google/android/libraries/mapsplatform/secrets_gradle_plugin/SecretsPlugin.kt
+++ b/secrets-gradle-plugin/src/main/java/com/google/android/libraries/mapsplatform/secrets_gradle_plugin/SecretsPlugin.kt
@@ -15,6 +15,7 @@
 
 package com.google.android.libraries.mapsplatform.secrets_gradle_plugin
 
+import com.android.build.api.variant.TestComponent
 import com.android.build.api.variant.Variant
 import com.android.build.gradle.internal.core.InternalBaseVariant
 import org.gradle.api.Plugin
@@ -68,11 +69,11 @@ class SecretsPlugin : Plugin<Project> {
     ) {
         // Inject defaults first
         defaultProperties?.let {
-            variant.inject(it, extension.ignoreList)
+            variant.injectWithTestComponents(it, extension.ignoreList)
         }
 
         properties?.let {
-            variant.inject(properties, extension.ignoreList)
+            variant.injectWithTestComponents(properties, extension.ignoreList)
         }
 
         // Inject build-type specific properties
@@ -83,7 +84,7 @@ class SecretsPlugin : Plugin<Project> {
             null
         }
         buildTypeProperties?.let {
-            variant.inject(it, extension.ignoreList)
+            variant.injectWithTestComponents(it, extension.ignoreList)
         }
 
         // Inject flavor-specific properties
@@ -94,7 +95,16 @@ class SecretsPlugin : Plugin<Project> {
             null
         }
         flavorProperties?.let {
-            variant.inject(it, extension.ignoreList)
+            variant.injectWithTestComponents(it, extension.ignoreList)
+        }
+    }
+
+    // Inject the main variant plus its test components, whose manifests reference the same
+    // placeholders; otherwise AGP fails the test manifest merge with "no value provided".
+    private fun Variant.injectWithTestComponents(properties: Properties, ignore: List<String>) {
+        inject(properties, ignore)
+        nestedComponents.filterIsInstance<TestComponent>().forEach { testComponent ->
+            testComponent.inject(properties, ignore)
         }
     }
 }

--- a/secrets-gradle-plugin/src/test/kotlin/com/google/android/libraries/mapsplatform/secrets_gradle_plugin/SecretsPluginTest.kt
+++ b/secrets-gradle-plugin/src/test/kotlin/com/google/android/libraries/mapsplatform/secrets_gradle_plugin/SecretsPluginTest.kt
@@ -14,6 +14,7 @@
 
 package com.google.android.libraries.mapsplatform.secrets_gradle_plugin
 
+import com.android.build.api.variant.TestComponent
 import com.android.build.gradle.internal.core.InternalBaseVariant
 import com.nhaarman.mockitokotlin2.doReturn
 import com.nhaarman.mockitokotlin2.mock
@@ -93,6 +94,28 @@ class SecretsPluginTest {
             Pair("key", "someValue")
         )
         checkKeysNotIn("ignoreKey", "sdk.dir", "sdk.foo")
+    }
+
+    @Test
+    fun `test component receives manifest placeholders`() {
+        val fileName = "local.properties"
+        val propertiesFile = tempFolder.newFile(fileName)
+        propertiesFile.writeText(
+            """
+            MAPS_API_KEY="someValue"
+            ignoreKey="sadf"
+        """.trimIndent()
+        )
+        val properties = project.rootProject.loadPropertiesFile(fileName)
+        val testPlaceholders = project.objects.mapProperty(String::class.java, String::class.java)
+        val testComponent = mock<TestComponent> {
+            on { manifestPlaceholders } doReturn testPlaceholders
+        }
+
+        testComponent.inject(properties = properties, ignore = listOf("ignoreKey"))
+
+        Assert.assertEquals("someValue", testPlaceholders.get()["MAPS_API_KEY"])
+        Assert.assertFalse(testPlaceholders.get().containsKey("ignoreKey"))
     }
 
     @Test


### PR DESCRIPTION
Fixes #41.

## Problem

The plugin injects manifest placeholders only into the **main variant**. Both unit-test and android-test manifests are merged from the same sources and reference the same placeholders (e.g. `${MAPS_API_KEY}`), but they never receive a value.

This was harmless until AGP started validating the **test** manifest merge. On recent AGP versions `processDebugUnitTestManifest` (and the equivalent android-test task) fails the build:

```
Attribute meta-data#com.google.android.geo.API_KEY@value at AndroidManifest.xml
requires a placeholder substitution but no value for <MAPS_API_KEY> is provided.
Validation failed, exiting
```

The main/release build works fine — only test variants break. This is the same `<MAPS_API_KEY> not provided` failure reported in #41 (the `Try to repro #41` branch confirms it reproduces).

### Isolation

Triggered purely by the AGP version, everything else held constant:

| AGP | `processDebugUnitTestManifest` |
|-----|-------------------------------|
| 9.0.1 | ✅ passes |
| 9.1.1 | ❌ fails (`<MAPS_API_KEY> not provided`) |

## Fix

After injecting the main variant, also inject **manifest placeholders** into its nested test components:

- Add `TestComponent.inject` applying only manifest placeholders (test components don't generate a `BuildConfig`, so unlike `Variant.inject` it skips `buildConfigFields`). Since both **UnitTest and AndroidTest** are the variant's nested `TestComponent`s, iterating `nestedComponents` covers both.
- In `SecretsPlugin`, inject the nested test components alongside the main variant for every property source (defaults, properties, build-type, flavor).
- Bump the compiled-against AGP `7.0.4 → 7.4.0` — the **first version** where `TestComponent.manifestPlaceholders` exists — kept as low as possible to preserve compatibility for consumers still on AGP 7.x. (The sample app and tests keep building against 8.4.2 to exercise the fix on newer AGP.)

## Test

Added `test component receives manifest placeholders`, verifying injection and ignore-list handling. The plugin compiles against AGP 7.4.0; the sample app and tests run against 8.4.2. All existing tests pass.

